### PR TITLE
Feature/add info page

### DIFF
--- a/IslandLanding/IslandLanding/ViewModel/DifficuilityViewModel.cs
+++ b/IslandLanding/IslandLanding/ViewModel/DifficuilityViewModel.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Input;
+using Xamarin.Forms;
+
+namespace IslandLanding.ViewModel
+{
+  public class DifficuilityViewModel : BaseViewModel
+  {
+    public ICommand BackCommand { get; set; }
+    public DifficuilityViewModel()
+    {
+      BackCommand = new Command(BackCommandExcute);
+    }
+
+    private void BackCommandExcute(object obj)
+    {
+      App.Current.MainPage.Navigation.PopAsync();
+    }
+  }
+}

--- a/IslandLanding/IslandLanding/ViewModel/InfoViewModel.cs
+++ b/IslandLanding/IslandLanding/ViewModel/InfoViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Windows.Input;
+using Xamarin.Essentials;
 using Xamarin.Forms;
 
 namespace IslandLanding.ViewModel
@@ -15,8 +16,10 @@ namespace IslandLanding.ViewModel
       set => SetProperty(ref _rules, value);
     }
     public ICommand BackCommand { get; set; }
+    public ICommand CheckusCommand { get; set; }
     public InfoViewModel()
     {
+      CheckusCommand = new Command(CheckusCommandExcute);
       BackCommand = new Command(BackCommandExcute);
       Rules = @"Use this brain training game to improve your time sensibitiliy. When you are ready, you can click the Ready button and count the assigned time by the captain in your mind. 
 
@@ -24,6 +27,19 @@ You can click on the Launch Parachute button when you think the time has elapsed
 
 This game is developed by The First Prototype.We help mers love, and we specialize in mobile app development.Background vectors created by pikisuperstar";
     }
+
+    private async void CheckusCommandExcute(object obj)
+    {
+      try
+      {
+        await Browser.OpenAsync("https://thefirstprototype.com/", BrowserLaunchMode.SystemPreferred);
+      }
+      catch (Exception ex)
+      {
+        // An unexpected error occured. No browser may be installed on the device.
+      }
+    }
+
     private void BackCommandExcute(object obj)
     {
       App.Current.MainPage.Navigation.PopAsync();

--- a/IslandLanding/IslandLanding/ViewModel/InfoViewModel.cs
+++ b/IslandLanding/IslandLanding/ViewModel/InfoViewModel.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Input;
+using Xamarin.Forms;
+
+namespace IslandLanding.ViewModel
+{
+  public class InfoViewModel : BaseViewModel
+  {
+    string _rules;
+    public string Rules
+    {
+      get => _rules;
+      set => SetProperty(ref _rules, value);
+    }
+    public ICommand BackCommand { get; set; }
+    public InfoViewModel()
+    {
+      BackCommand = new Command(BackCommandExcute);
+      Rules = @"Use this brain training game to improve your time sensibitiliy. When you are ready, you can click the Ready button and count the assigned time by the captain in your mind. 
+
+You can click on the Launch Parachute button when you think the time has elapsed.If your time difference is less than 1 second, you can proceed to next level. Pass 10 levels to submit your average to the scoreboard!
+
+This game is developed by The First Prototype.We help mers love, and we specialize in mobile app development.Background vectors created by pikisuperstar";
+    }
+    private void BackCommandExcute(object obj)
+    {
+      App.Current.MainPage.Navigation.PopAsync();
+
+    }
+  }
+}

--- a/IslandLanding/IslandLanding/Views/DificullityPage.xaml
+++ b/IslandLanding/IslandLanding/Views/DificullityPage.xaml
@@ -1,12 +1,73 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="IslandLanding.Views.DificullityPage">
+             x:Class="IslandLanding.Views.DificullityPage"
+             NavigationPage.HasNavigationBar="False">
     <ContentPage.Content>
-        <StackLayout>
-            <Label Text="Welcome to Xamarin.Forms!"
-                VerticalOptions="CenterAndExpand" 
-                HorizontalOptions="CenterAndExpand" />
-        </StackLayout>
+    <Grid RowDefinitions="auto,auto">
+      <Image Source="background" Grid.RowSpan="2" Opacity="0.3"
+                  Aspect="Fill"/>
+      <Image Margin="30,45,0,0" Grid.Row="0"
+             HorizontalOptions="Start"
+             HeightRequest="24"
+             WidthRequest="24"
+           
+             VerticalOptions="Center"
+           >
+        <Image.Source>
+          <FontImageSource Color="{StaticResource orange}"
+                                         FontFamily="FontAwesome5Solid"
+                                         Glyph="&#xf053;"/>
+        </Image.Source>
+        <Image.GestureRecognizers>
+          <TapGestureRecognizer Command="{Binding BackCommand}"  NumberOfTapsRequired="1"/>
+        </Image.GestureRecognizers>
+      </Image>
+      <StackLayout Grid.Row="1" Margin="0,170,0,0">
+        <Button 
+              WidthRequest="300"
+              Text="Easy"
+              Margin="40,0,40,0"
+              TextColor="White"
+              BorderColor="{StaticResource bordercolor}"
+              BorderWidth="4" 
+              HeightRequest="60"
+              CornerRadius="30"
+              BackgroundColor="{StaticResource orange}"
+             FontFamily="PatrickFont"
+             FontSize="20"
+             Command="{Binding StartCommand}"
+              />
+        <Button 
+              WidthRequest="300"
+              Text="Medium"
+              Margin="40,20,40,20"
+              TextColor="White"
+              BorderColor="{StaticResource bordercolor}"
+              BorderWidth="4" 
+              HeightRequest="60"
+              CornerRadius="30"
+              BackgroundColor="{StaticResource orange}"
+             FontFamily="PatrickFont"
+             FontSize="20"
+             Command="{Binding StartCommand}"
+              />
+        <Button 
+              WidthRequest="300"
+              Text="Hard"
+              Margin="40,0,40,0"
+              TextColor="White"
+              BorderColor="{StaticResource bordercolor}"
+              BorderWidth="4" 
+              HeightRequest="60"
+              CornerRadius="30"
+              BackgroundColor="{StaticResource orange}"
+             FontFamily="PatrickFont"
+             FontSize="20"
+             Command="{Binding StartCommand}"
+              />
+      </StackLayout>
+      
+        </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/IslandLanding/IslandLanding/Views/GamerTagPage.xaml
+++ b/IslandLanding/IslandLanding/Views/GamerTagPage.xaml
@@ -7,7 +7,7 @@
              >
     <ContentPage.Content>
     <Grid>
-      <Image Source="background" 
+      <Image Source="background" Opacity="0.3"
                   Aspect="Fill"/>
       <controls:GamerTagTemplate TitleText="Please enter your gamer tag"
                                SubmitCommand="{Binding SaveCommand}"

--- a/IslandLanding/IslandLanding/Views/HomePage.xaml
+++ b/IslandLanding/IslandLanding/Views/HomePage.xaml
@@ -5,7 +5,9 @@
              NavigationPage.HasNavigationBar="False">
     <ContentPage.Content>
     <Grid RowDefinitions="auto,auto,auto">
-      <Image Source="background" Grid.RowSpan="3"
+      <Image Source="background"
+             Opacity="0.3"
+              Grid.RowSpan="3"
                   Aspect="Fill"/>
       <Image Grid.Row="0" Margin="24,30,0,30"
              HorizontalOptions="Start"

--- a/IslandLanding/IslandLanding/Views/InfoPage.xaml
+++ b/IslandLanding/IslandLanding/Views/InfoPage.xaml
@@ -1,12 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="IslandLanding.Views.InfoPage">
+              x:Class="IslandLanding.Views.InfoPage"
+              NavigationPage.HasNavigationBar="False">
     <ContentPage.Content>
-        <StackLayout>
-            <Label Text="Welcome to Xamarin.Forms!"
-                VerticalOptions="CenterAndExpand" 
-                HorizontalOptions="CenterAndExpand" />
-        </StackLayout>
-    </ContentPage.Content>
+    <Grid RowDefinitions="auto,auto,auto">
+      <Image Source="background" Grid.RowSpan="3" Opacity="0.3"
+                  Aspect="Fill"/>
+      <Image Margin="30,45,0,0" Grid.Row="0"
+             HorizontalOptions="Start"
+             HeightRequest="24"
+             WidthRequest="24"
+           
+             VerticalOptions="Center"
+           >
+        <Image.Source>
+          <FontImageSource Color="White"
+                                         FontFamily="FontAwesome5Solid"
+                                         Glyph="&#xf053;"/>
+        </Image.Source>
+        <Image.GestureRecognizers>
+          <TapGestureRecognizer Command="{Binding BackCommand}"  NumberOfTapsRequired="1"/>
+        </Image.GestureRecognizers>
+      </Image>
+      <Label Grid.Row="1" Margin="0,-25,0,0"
+             HorizontalOptions="Center"
+             VerticalOptions="Center"
+             TextColor="White"
+             Text="Game rules"
+             FontSize="60"
+             FontFamily="PatrickFont"/>
+      <Label Grid.Row="2"
+             Margin="30,0"
+             Text="{Binding Rules}"
+             MaxLines="30"
+             TextColor="White"
+             FontSize="20"
+             FontFamily="PatrickFont"/>
+    </Grid>
+  </ContentPage.Content>
 </ContentPage>

--- a/IslandLanding/IslandLanding/Views/InfoPage.xaml
+++ b/IslandLanding/IslandLanding/Views/InfoPage.xaml
@@ -4,8 +4,8 @@
               x:Class="IslandLanding.Views.InfoPage"
               NavigationPage.HasNavigationBar="False">
     <ContentPage.Content>
-    <Grid RowDefinitions="auto,auto,auto">
-      <Image Source="background" Grid.RowSpan="3" Opacity="0.3"
+    <Grid RowDefinitions="auto,auto,auto,auto">
+      <Image Source="background" Grid.RowSpan="4" Opacity="0.3"
                   Aspect="Fill"/>
       <Image Margin="30,45,0,0" Grid.Row="0"
              HorizontalOptions="Start"
@@ -31,12 +31,23 @@
              FontSize="60"
              FontFamily="PatrickFont"/>
       <Label Grid.Row="2"
-             Margin="30,0"
+             Margin="30,-10,30,0"
              Text="{Binding Rules}"
-             MaxLines="30"
              TextColor="White"
              FontSize="20"
              FontFamily="PatrickFont"/>
+      <Label Grid.Row="3"
+             Margin="30,0"
+             Text="Check us out here!"
+             TextDecorations="Underline"
+             TextColor="White"
+             FontSize="20"
+             FontFamily="PatrickFont">
+        <Label.GestureRecognizers>
+          <TapGestureRecognizer Command="{Binding CheckusCommand}"/>
+        </Label.GestureRecognizers>
+      </Label>
+
     </Grid>
   </ContentPage.Content>
 </ContentPage>

--- a/IslandLanding/IslandLanding/Views/InfoPage.xaml.cs
+++ b/IslandLanding/IslandLanding/Views/InfoPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using IslandLanding.ViewModel;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -15,6 +16,7 @@ namespace IslandLanding.Views
     public InfoPage()
     {
       InitializeComponent();
+      BindingContext = new InfoViewModel();
     }
   }
 }

--- a/IslandLanding/IslandLanding/Views/SwitchUserAccountPage.xaml
+++ b/IslandLanding/IslandLanding/Views/SwitchUserAccountPage.xaml
@@ -8,8 +8,10 @@
              >
   <ContentPage.Content>
     <Grid RowDefinitions="auto,auto">
-      <Image Source="background" Grid.RowSpan="2"
-                  Aspect="Fill"/>
+      <Image Source="background"
+             Grid.RowSpan="2"
+             Opacity="0.3"
+              Aspect="Fill"/>
       <Image Margin="24,38,0,0" Grid.Row="0"
              HorizontalOptions="Start"
              HeightRequest="24"

--- a/IslandLanding/IslandLanding/Views/TutorialPage.xaml
+++ b/IslandLanding/IslandLanding/Views/TutorialPage.xaml
@@ -6,7 +6,8 @@
     <ContentPage.Content>
     <Grid >
       <Image Source="background" 
-                  Aspect="Fill"/>
+             Aspect="Fill"
+             Opacity="0.3"/>
 
       <CarouselView     Margin="0,180,0,30"
                         x:Name="carousel"


### PR DESCRIPTION
### AddInfoPage && Difficulty page ui 

- Create Add info design as Figma 
- when press on back return to home page 
- when press on check us  will navigate to website
- make the opacity for background image 0.3 
- create design for difficulty page as figma
- when press on back arrow return to home 

### Testing 
IOS>home page>press infoicon>go to infopage
Android >home page>press infoicon>go to infopage
IOS>home page> press start>go to Difficulty page
Android >home page>press start>go to Difficulty page
![image](https://user-images.githubusercontent.com/10218465/111327581-2c27c980-8676-11eb-974b-9b50ebd314ab.png)
